### PR TITLE
mobile menu syling

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -72,6 +72,7 @@ header a {
 .menu-content ul a {
   height: 100%;
   width: 100%;
+  white-space: nowrap;
 }
 
 .menu-content ul li {


### PR DESCRIPTION
proximos pasos option in mobile menu no longer wraps to next line when menu is opening and closing